### PR TITLE
Update: Init, Fuzzing, Eq

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,31 @@
+
+[package]
+name = "bls_eth_rust-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.bls_eth_rust]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_signature_serialization"
+path = "fuzz_targets/fuzz_signature_serialization.rs"
+
+[[bin]]
+name = "fuzz_publickey_serialization"
+path = "fuzz_targets/fuzz_publickey_serialization.rs"
+
+[[bin]]
+name = "fuzz_secretkey_serialization"
+path = "fuzz_targets/fuzz_secretkey_serialization.rs"

--- a/fuzz/fuzz_targets/fuzz_publickey_serialization.rs
+++ b/fuzz/fuzz_targets/fuzz_publickey_serialization.rs
@@ -3,5 +3,5 @@ use libfuzzer_sys::fuzz_target;
 use bls_eth_rust::PublicKey;
 
 fuzz_target!(|data: &[u8]| {
-    let sig = PublicKey::from_serialized(data);
+    let _pk = PublicKey::from_serialized(data);
 });

--- a/fuzz/fuzz_targets/fuzz_publickey_serialization.rs
+++ b/fuzz/fuzz_targets/fuzz_publickey_serialization.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use bls_eth_rust::PublicKey;
+
+fuzz_target!(|data: &[u8]| {
+    let sig = PublicKey::from_serialized(data);
+});

--- a/fuzz/fuzz_targets/fuzz_secretkey_serialization.rs
+++ b/fuzz/fuzz_targets/fuzz_secretkey_serialization.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use bls_eth_rust::SecretKey;
+
+fuzz_target!(|data: &[u8]| {
+    let sig = SecretKey::from_serialized(data);
+});

--- a/fuzz/fuzz_targets/fuzz_secretkey_serialization.rs
+++ b/fuzz/fuzz_targets/fuzz_secretkey_serialization.rs
@@ -3,5 +3,5 @@ use libfuzzer_sys::fuzz_target;
 use bls_eth_rust::SecretKey;
 
 fuzz_target!(|data: &[u8]| {
-    let sig = SecretKey::from_serialized(data);
+    let _sk = SecretKey::from_serialized(data);
 });

--- a/fuzz/fuzz_targets/fuzz_signature_serialization.rs
+++ b/fuzz/fuzz_targets/fuzz_signature_serialization.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use bls_eth_rust::Signature;
+
+fuzz_target!(|data: &[u8]| {
+    let sig = Signature::from_serialized(data);
+});

--- a/fuzz/fuzz_targets/fuzz_signature_serialization.rs
+++ b/fuzz/fuzz_targets/fuzz_signature_serialization.rs
@@ -3,5 +3,5 @@ use libfuzzer_sys::fuzz_target;
 use bls_eth_rust::Signature;
 
 fuzz_target!(|data: &[u8]| {
-    let sig = Signature::from_serialized(data);
+    let _sig = Signature::from_serialized(data);
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ macro_rules! serialize_impl {
                     n = $serialize_fn(buf.as_mut_ptr(), size, self);
                 }
                 if n == 0 {
-                    panic!("serialize");
+                    panic!("BLS serialization error");
                 }
                 unsafe {
                     buf.set_len(n);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,9 @@ macro_rules! serialize_impl {
                 }
                 buf
             }
+            pub fn as_bytes(&self) -> Vec<u8> {
+                self.serialize()
+            }
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ macro_rules! common_impl {
                 unsafe { $is_equal_fn(self, rhs) == 1 }
             }
         }
+        impl Eq for $t {}
         impl $t {
             pub fn zero() -> $t {
                 Default::default()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,6 +7,9 @@ macro_rules! serialize_test {
         let mut y: $t = unsafe { <$t>::uninit() };
         assert!(y.deserialize(&buf));
         assert_eq!($x, y);
+
+        let z = <$t>::from_serialized(&buf);
+        assert_eq!($x, z.unwrap());
     };
 }
 
@@ -15,7 +18,7 @@ fn test() {
     assert_eq!(mem::size_of::<SecretKey>(), 32);
     assert_eq!(mem::size_of::<PublicKey>(), 48 * 3);
     assert_eq!(mem::size_of::<Signature>(), 48 * 2 * 3);
-    assert!(init(CurveType::BLS12_381));
+    //assert!(init(CurveType::BLS12_381));
 
     let msg = Message::zero();
     let mut seckey = unsafe { SecretKey::uninit() };
@@ -27,9 +30,9 @@ fn test() {
     serialize_test! {SecretKey, seckey};
     serialize_test! {PublicKey, pubkey};
     serialize_test! {Signature, sig};
-    test_aggregate();
 }
 
+#[test]
 fn test_aggregate() {
     let mut seckey = unsafe { SecretKey::uninit() };
     seckey.set_by_csprng();
@@ -56,4 +59,18 @@ fn test_aggregate() {
         agg_sig.add_assign(&sigs[i])
     }
     assert!(agg_sig.verify_aggregated_message(&pubs[..], &msgs[..]));
+}
+
+#[test]
+fn test_from_serialized_signature() {
+    //assert!(init(CurveType::BLS12_381));
+    let data = [0u8; 0];
+    let sig = Signature::from_serialized(&data);
+}
+
+#[test]
+fn test_from_serialized_publickey() {
+    //assert!(init(CurveType::BLS12_381));
+    let data = [0u8; 0];
+    let pk = PublicKey::from_serialized(&data);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -14,11 +14,10 @@ macro_rules! serialize_test {
 }
 
 #[test]
-fn test() {
+fn test_sign_serialize() {
     assert_eq!(mem::size_of::<SecretKey>(), 32);
     assert_eq!(mem::size_of::<PublicKey>(), 48 * 3);
     assert_eq!(mem::size_of::<Signature>(), 48 * 2 * 3);
-    //assert!(init(CurveType::BLS12_381));
 
     let msg = Message::zero();
     let mut seckey = unsafe { SecretKey::uninit() };
@@ -63,14 +62,12 @@ fn test_aggregate() {
 
 #[test]
 fn test_from_serialized_signature() {
-    //assert!(init(CurveType::BLS12_381));
     let data = [0u8; 0];
     let sig = Signature::from_serialized(&data);
 }
 
 #[test]
 fn test_from_serialized_publickey() {
-    //assert!(init(CurveType::BLS12_381));
     let data = [0u8; 0];
     let pk = PublicKey::from_serialized(&data);
 }


### PR DESCRIPTION
# Changes

In this PR I've made 4 main changes
- Included the trait `Eq` as part of `common_impl`
- Added Fuzzing for deserialisation
- Wrapped `blsInit()` in a `Once` modifier which means that it will only ever be called once
- Split out some of the tests